### PR TITLE
Port from gnome-keyring to libsecret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TARGET = gnome-keyring
 
-KEYRINGFLAGS = `pkg-config --libs --cflags gnome-keyring-1`
+SECRETFLAGS = `pkg-config --libs --cflags libsecret-1`
 PURPLEFLAGS = `pkg-config --cflags purple`
 VERSION = $(shell cat VERSION)
 ifeq ($(strip $(VERSION)),)
@@ -15,7 +15,7 @@ clean:
 
 ${TARGET}.so: ${TARGET}.c
 
-	${CC} -Wall -I. -g -O2 ${TARGET}.c -o ${TARGET}.so -shared -fPIC -DPIC -ggdb ${PURPLEFLAGS} ${KEYRINGFLAGS} -DVERSION=\"${VERSION}\"
+	${CC} -Wall -I. -g -O2 ${TARGET}.c -o ${TARGET}.so -shared -fPIC -DPIC -ggdb ${PURPLEFLAGS} ${SECRETFLAGS} -DVERSION=\"${VERSION}\"
 
 install: ${TARGET}.so
 	mkdir -p /usr/lib/purple-2/

--- a/deb_control
+++ b/deb_control
@@ -2,7 +2,7 @@ Source: pidgin-gnome-keyring
 Section: universe/net
 Priority: optional
 Maintainer: Ali Ebrahim <ali.ebrahim314@gmail.com>
-Build-Depends: debhelper (>= 9), pkg-config, libgnome-keyring-dev, libpurple-dev
+Build-Depends: debhelper (>= 9), pkg-config, libsecret-1-dev, libpurple-dev
 Standards-Version: 3.9.5
 Homepage: https://github.com/aebrahim/pidgin-gnome-keyring/
 Vcs-git: https://github.com/aebrahim/pidgin-gnome-keyring.git
@@ -10,6 +10,6 @@ Vcs-Browser: https://github.com/aebrahim/pidgin-gnome-keyring/
 
 Package: pidgin-gnome-keyring
 Architecture: any
-Depends: ${misc:Depends}, libgnome-keyring0, libpurple0
+Depends: ${misc:Depends}, libsecret-1-0, libpurple0
 Description: integrates pidgin (and libpurple) with the GNOME keyring
  Pidgin usually stores passwords as plaintext with the "save password" function. This plugin instead saves all passwords to the gnome keyring, which some would argue is a more secure form of password storage. 


### PR DESCRIPTION
Hello,

Since libgnome-keyring is being deprecated, I attempted a port to libsecret. I tested this on Debian Jessie x86_64bit with Pidgin 2.10.11, on Facebook/Google Talk/ICQ and it works.

One nice thing about libsecret is that it's not restricted to gnome, so in theory the plugin should also work on KDE with KWallet, although I don't have a KDE installation so I have not tested it :-)

Please let me know if you have any comments!

Luca