### PR TITLE
Added CFLAGS and install in DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ clean:
 
 ${TARGET}.so: ${TARGET}.c
 
-	${CC} -Wall -I. -g -O2 ${TARGET}.c -o ${TARGET}.so -shared -fPIC -DPIC -ggdb ${PURPLEFLAGS} ${SECRETFLAGS} -DVERSION=\"${VERSION}\"
+	${CC} ${CFLAGS} ${LDFLAGS} -Wall -I. -g -O2 ${TARGET}.c -o ${TARGET}.so -shared -fPIC -DPIC -ggdb ${PURPLEFLAGS} ${SECRETFLAGS} -DVERSION=\"${VERSION}\"
 
 install: ${TARGET}.so
-	mkdir -p /usr/lib/purple-2/
-	cp ${TARGET}.so /usr/lib/purple-2/
+	mkdir -p ${DESTDIR}/usr/lib/purple-2/
+	cp ${TARGET}.so ${DESTDIR}/usr/lib/purple-2/
 
 install_local: ${TARGET}.so
 	mkdir -p ~/.purple/plugins


### PR DESCRIPTION
Hello,

Another small fix for the Makefile. I added ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} so that dh can correctly do hardening at build time (nice to have, for a library that handles passwords :-) ). Also changed install target to point to ${DESTDIR}/... so that dh can build in the temporary directory and then package.

I made these 2 small changes because I'm trying to package pidgin-gnome-keyring for Debian, and I will try to push it in the distro. Hope they can be useful!

Luca